### PR TITLE
Fixing of device info for RB5 linux kernel 5.x and ubuntu 20.04 LU2.0

### DIFF
--- a/RB5/linux_kernel_5_x/platform-bringup/Device-info/src/qrb5165_info.c
+++ b/RB5/linux_kernel_5_x/platform-bringup/Device-info/src/qrb5165_info.c
@@ -20,7 +20,7 @@
 #define FILE_HDMISTATE "/sys/class/drm/card0-DSI-1/status"
 #define FILE_CAN_FLAGS "/sys/class/net/can0/flags"
 #define FILE_IOMEM     "/proc/iomem"
-#define FILE_GPUINFO   "/sys/devices/platform/soc/5900000.qcom,kgsl-3d0/devfreq/5900000.qcom,kgsl-3d0/%s"
+#define FILE_GPUINFO   "/sys/devices/platform/soc/3d00000.qcom,kgsl-3d0/devfreq/3d00000.qcom,kgsl-3d0/%s"
 
 #define GPU_GOVERNOR   "governor"
 #define GPU_CUR_FREQ   "cur_freq"


### PR DESCRIPTION
In the file for device-info for the RB5 , linux kernel 5.x ubuntu 20.04 image, the details for GPU for the following line:

#define FILE_GPUINFO   "/sys/devices/platform/soc/5900000.qcom,kgsl-3d0/devfreq/5900000.qcom,kgsl-3d0/%s"

Should be changed to:

#define FILE_GPUINFO   "/sys/devices/platform/soc/3d00000.qcom,kgsl-3d0/devfreq/3d00000.qcom,kgsl-3d0/%s"

![rb5](https://github.com/quic/sample-apps-for-robotics-platforms/assets/54789584/ab12dc8d-2cde-428c-8f50-9580699052d3)


