### PR TITLE
Change of FILE_GPUINFO line

### DIFF
--- a/RB5/linux_kernel_5_x/platform-bringup/Device-info/src/qrb5165_info.c
+++ b/RB5/linux_kernel_5_x/platform-bringup/Device-info/src/qrb5165_info.c
@@ -20,7 +20,7 @@
 #define FILE_HDMISTATE "/sys/class/drm/card0-DSI-1/status"
 #define FILE_CAN_FLAGS "/sys/class/net/can0/flags"
 #define FILE_IOMEM     "/proc/iomem"
-#define FILE_GPUINFO   "/sys/devices/platform/soc/5900000.qcom,kgsl-3d0/devfreq/5900000.qcom,kgsl-3d0/%s"
+#define FILE_GPUINFO   "/sys/devices/platform/soc/3d00000.qcom,kgsl-3d0/devfreq/3d00000.qcom,kgsl-3d0/%s"
 
 #define GPU_GOVERNOR   "governor"
 #define GPU_CUR_FREQ   "cur_freq"


### PR DESCRIPTION
The file for device-info in RB5 - Kernel 5.x - running on ubuntu 20.04 LU2.0 needs to be fixed for viewing GPU information:

![rb5](https://github.com/quic/sample-apps-for-robotics-platforms/assets/54789584/c0bf217a-79d0-411f-88c5-0a2339564acd)


it should be 3d00000.qcom not 5900000.qcom